### PR TITLE
Psion changes final part

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -36,6 +36,8 @@
 	restricted_jobs = list(
 		/datum/job/doctor,
 		/datum/job/recovery_team,
+		/datum/job/roboticist,//Coffee edit: Now RD can also do a little bit of psych-research and healing. Still, RD ain't starting with Mind Master(So no +5 Psi-Points)
+		/datum/job/scientist,
 		/datum/job/premier,
 		/datum/job/pg,
 		/datum/job/chaplain,
@@ -46,7 +48,7 @@
 		/datum/job/swo
 	) // The way to restrict this to one job could be done cleaner but this way easier so fuck it. -Kaz
 	allow_modifications = FALSE
-	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | SCIENCE | CHURCH | INDEPENDENT | CIVILIAN | LSS
+	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | CHURCH | INDEPENDENT | CIVILIAN | LSS
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_MYCUS, FORM_FOLKEN, FORM_CHTMANT)
 
 /datum/category_item/setup_option/core_implant/nanogate

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -43,7 +43,6 @@
 		/datum/job/chaplain,
 		/datum/job/chief_engineer,
 		/datum/job/merchant,
-		/datum/job/rd,
 		/datum/job/smc,
 		/datum/job/swo
 	) // The way to restrict this to one job could be done cleaner but this way easier so fuck it. -Kaz

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -206,7 +206,7 @@
 	anchored = TRUE
 	var/catalyst_drop = /obj/random/psi_catalyst
 	var/psion_chance = 30//Coffee edit: 25->30
-	var/normie_chance = 20//15->20
+	var/normie_chance = 15//10->15
 
 /obj/effect/decal/cleanable/psi_ash/attack_hand(mob/user as mob)
 	if(user.stats.getPerk(PERK_PSION) && prob(psion_chance))

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -205,8 +205,8 @@
 	icon_state = "ash"
 	anchored = TRUE
 	var/catalyst_drop = /obj/random/psi_catalyst
-	var/psion_chance = 25
-	var/normie_chance = 10
+	var/psion_chance = 40//Coffee edit: Now you can find them a bit more, so you can collect them faster and RP w/ 'em a bit more.
+	var/normie_chance = 15
 
 /obj/effect/decal/cleanable/psi_ash/attack_hand(mob/user as mob)
 	if(user.stats.getPerk(PERK_PSION) && prob(psion_chance))

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -205,8 +205,8 @@
 	icon_state = "ash"
 	anchored = TRUE
 	var/catalyst_drop = /obj/random/psi_catalyst
-	var/psion_chance = 40//Coffee edit: Now you can find them a bit more, so you can collect them faster and RP w/ 'em a bit more.
-	var/normie_chance = 15
+	var/psion_chance = 30//Coffee edit: 25->30
+	var/normie_chance = 20//15->20
 
 /obj/effect/decal/cleanable/psi_ash/attack_hand(mob/user as mob)
 	if(user.stats.getPerk(PERK_PSION) && prob(psion_chance))


### PR DESCRIPTION
1)RD now can choose Cultured psion flesh - to heal others a bit, since we're low on proper med-staff. Doesn't provide Mind Master(So no +5 psipoints)
2)Dropchance of the psion catalysts increased from 25 -> 40 for psions, and 10 -> 15 for non-psions. Now you won't waste one hour straight just for one ability to show off w/ your friends.

P.s. help me i'm all alone in medbay