### PR TITLE
Subtle(Anti-ghost) verb

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,7 +1,7 @@
 // All mobs should have custom emote, really..
 //m_type == 1 --> visual.
 //m_type == 2 --> audible
-/mob/proc/custom_emote(var/m_type=1,var/message = null,var/range=world.view)
+/mob/proc/custom_emote(var/m_type=1,var/message = null,var/range=world.view,var/antighost=FALSE)
 	if(usr && stat || !use_me && usr == src)
 		to_chat(src, "You are unable to emote.")
 		return
@@ -24,7 +24,7 @@
 	if (message)
 		log_emote("[name]/[key] : [message]")
 
-		send_emote(message, m_type, range)
+		send_emote(message, m_type, range, antighost)
 
 /mob/proc/format_emote(var/emoter = null, var/input = null)
 	var/message = "<B>[src]</B> [input]"
@@ -65,7 +65,7 @@
 		say_dead_direct(input, src)
 
 //This is a central proc that all emotes are run through. This handles sending the messages to living mobs
-/mob/proc/send_emote(var/message, var/type, var/range = world.view)
+/mob/proc/send_emote(var/message, var/type, var/range = world.view, var/antighost=FALSE)
 	var/list/messageturfs = list()//List of turfs we broadcast to.
 	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
 	var/list/messagemobs_neardead = list()//List of nearby ghosts who can hear it. Those that qualify ONLY go in this list
@@ -74,6 +74,8 @@
 
 	for(var/mob/M in GLOB.player_list)
 		if (!M.client || istype(M, /mob/new_player))
+			continue
+		if (antighost && istype(M, /mob/observer))
 			continue
 		if(get_turf(M) in messageturfs)
 			if (istype(M, /mob/observer))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -155,7 +155,7 @@
 				return
 			if(!(message))
 				return
-			return custom_emote(m_type, "<I>[message]</I>", 1)
+			return custom_emote(m_type, "<I>[message]</I>", 1, TRUE)
 
 		if("pain")
 			if(!message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -58,9 +58,9 @@
 	else
 		usr.emote(message)
 
-/*
+//Coffe Edit: Subtle is returned. Unholy.
 /mob/verb/subtle_wrapper()
-	set name = "Subtle verb"
+	set name = "Subtle (Anti-ghost) verb"
 	set category = "IC"
 
 	var/message = input("", "subtle (text)") as text|null
@@ -78,7 +78,7 @@
 		usr.emote("subtle", usr.emote_type, message)
 	else
 		usr.emote(message)
-*/
+
 /mob/proc/say_dead(message)
 	if(say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, SPAN_DANGER("Speech is currently admin-disabled."))


### PR DESCRIPTION
Что добавлено:
Возвращен Subtle (Anti-ghost) verb.
Что делает?
Позволяет писать эмоут, который не будет виден в гостоте. ~*ЕРП-куколды в гостоте заплакали*~